### PR TITLE
Add generator and generated SVG for FunGen-xQTL protocol workflow (2026 view)

### DIFF
--- a/code/images/generate_updated_workflow.py
+++ b/code/images/generate_updated_workflow.py
@@ -1,14 +1,63 @@
+"""Generate a condensed implementation-view workflow SVG.
+
+This figure is a companion to the detailed Lucidchart protocol schematic in
+``Protocol _2024_Mar.json``. It intentionally groups several Lucidchart nodes
+into broader repository-implementation categories so the downstream workflow is
+easier to read in documentation and presentations.
+"""
+
 from pathlib import Path
 import html
+import json
+import re
 
 OUT = Path(__file__).with_name('xQTL_Protocol_Implemented_2026.svg')
+LUCIDCHART_SOURCE = Path(__file__).with_name('Protocol _2024_Mar.json')
 W, H = 1640, 1080
+
+EXPECTED_LUCIDCHART_LABELS = [
+    'Existing GWAS & xQTL Summary Statistics',
+    'Context Specfic xQTL',
+    'Genotype Quality Control',
+    'Omics-data Quantification',
+    'Genome-wide xQTL Association',
+    'Genome-wide xQTL Fine-mapping',
+    'Colocalization',
+    'TWAS',
+    'Causal TWAS',
+    'Mendelian Randomization',
+    'Multi-Context xQTL',
+    'Variant-level Prioritization',
+    "Alzheimer's Disease",
+]
 
 COLORS = {
     'bg': '#fbfbf7', 'panel': '#ffffff', 'stroke': '#344054', 'muted': '#667085',
     'input': '#dbeafe', 'process': '#dcfce7', 'integrate': '#fee2e2',
     'validate': '#fef3c7', 'output': '#e0e7ff', 'line': '#344054', 'dash': '#94a3b8'
 }
+
+
+def lucidchart_labels():
+    if not LUCIDCHART_SOURCE.exists():
+        raise FileNotFoundError(f'Missing Lucidchart source: {LUCIDCHART_SOURCE}')
+    data = json.loads(LUCIDCHART_SOURCE.read_text())
+    labels = set()
+    for page in data.get('pages', []):
+        for shape in page.get('items', {}).get('shapes', []):
+            text = ' '.join(area.get('text', '') for area in shape.get('textAreas', []))
+            text = re.sub(r'\s+', ' ', text).strip()
+            if text:
+                labels.add(text)
+    return labels
+
+
+def assert_lucidchart_source_coverage():
+    labels = lucidchart_labels()
+    missing = [label for label in EXPECTED_LUCIDCHART_LABELS if label not in labels]
+    if missing:
+        raise ValueError('Expected Lucidchart labels are missing: ' + ', '.join(missing))
+    print(f'Audited {len(labels)} Lucidchart labels from {LUCIDCHART_SOURCE.name}')
 
 
 def wrap(text, max_chars):
@@ -62,7 +111,7 @@ svg = [
     f'<rect width="100%" height="100%" fill="{COLORS["bg"]}"/>',
 ]
 svg.append(text_block(W / 2, 48, ['FunGen-xQTL Protocol Workflow: implemented 2026 repository view'], size=30, weight='900'))
-svg.append(text_block(W / 2, 80, ['Solid arrows show implemented data flow; dashed panels group analysis families.'], size=16, weight='500', fill=COLORS['muted']))
+svg.append(text_block(W / 2, 80, ['Condensed implementation view audited against Protocol _2024_Mar.json; not a replacement for the detailed schematic.'], size=16, weight='500', fill=COLORS['muted']))
 
 svg.append(panel(50, 115, 340, 425, 'Inputs & reference data'))
 svg.append(panel(430, 115, 340, 425, 'QC, harmonization & covariates'))
@@ -129,6 +178,8 @@ for key, label in items:
     svg.append(f'<text x="{x + 38}" y="{legend_y - 4}" font-size="15" font-weight="600" fill="#374151">{html.escape(label)}</text>')
     x += 300 if key != 'input' else 180
 
+svg.append(text_block(W / 2, 1045, [f'Source audit: {LUCIDCHART_SOURCE.name}; grouped for readability and implementation status.'], size=14, weight='500', fill=COLORS['muted']))
 svg.append('</svg>')
+assert_lucidchart_source_coverage()
 OUT.write_text('\n'.join(svg))
 print(OUT)

--- a/code/images/generate_updated_workflow.py
+++ b/code/images/generate_updated_workflow.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+import html
+
+OUT = Path(__file__).with_name('xQTL_Protocol_Implemented_2026.svg')
+W, H = 1640, 1080
+
+COLORS = {
+    'bg': '#fbfbf7', 'panel': '#ffffff', 'stroke': '#344054', 'muted': '#667085',
+    'input': '#dbeafe', 'process': '#dcfce7', 'integrate': '#fee2e2',
+    'validate': '#fef3c7', 'output': '#e0e7ff', 'line': '#344054', 'dash': '#94a3b8'
+}
+
+
+def wrap(text, max_chars):
+    words = text.split()
+    lines, cur = [], ''
+    for word in words:
+        if len(cur) + len(word) + (1 if cur else 0) <= max_chars:
+            cur = f"{cur} {word}".strip()
+        else:
+            if cur:
+                lines.append(cur)
+            cur = word
+    if cur:
+        lines.append(cur)
+    return lines
+
+
+def text_block(x, y, lines, size=18, weight='600', fill='#111827', anchor='middle', line_height=1.2):
+    out = []
+    for idx, line in enumerate(lines):
+        dy = idx * size * line_height
+        out.append(f'<text x="{x}" y="{y + dy:.1f}" text-anchor="{anchor}" font-size="{size}" font-weight="{weight}" fill="{fill}">{html.escape(line)}</text>')
+    return '\n'.join(out)
+
+
+def box(x, y, w, h, title, subtitle='', fill='process', stroke=None, radius=14, title_size=19, sub_size=15, max_chars=24):
+    stroke = stroke or COLORS['stroke']
+    title_lines = wrap(title, max_chars)
+    sub_lines = wrap(subtitle, max_chars + 8) if subtitle else []
+    line_count = len(title_lines) + len(sub_lines)
+    start_y = y + h / 2 - ((line_count - 1) * title_size * 1.15) / 2 + title_size / 3
+    parts = [f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="{radius}" fill="{COLORS[fill]}" stroke="{stroke}" stroke-width="2"/>']
+    parts.append(text_block(x + w / 2, start_y, title_lines, size=title_size, weight='700'))
+    if sub_lines:
+        parts.append(text_block(x + w / 2, start_y + len(title_lines) * title_size * 1.18 + 6, sub_lines, size=sub_size, weight='500', fill=COLORS['muted']))
+    return '\n'.join(parts)
+
+
+def arrow(x1, y1, x2, y2, dash=False):
+    style = 'stroke-dasharray="8 8"' if dash else ''
+    return f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{COLORS["line"]}" stroke-width="3" marker-end="url(#arrow)" {style}/>'
+
+
+def panel(x, y, w, h, title):
+    return f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="18" fill="{COLORS["panel"]}" stroke="{COLORS["dash"]}" stroke-width="2.5" stroke-dasharray="14 10"/>\n' + text_block(x + w / 2, y + 34, [title], size=22, weight='800', fill='#1f2937')
+
+
+svg = [
+    f'<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" viewBox="0 0 {W} {H}">',
+    '<defs><marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L10,3 z" fill="#344054"/></marker></defs>',
+    f'<rect width="100%" height="100%" fill="{COLORS["bg"]}"/>',
+]
+svg.append(text_block(W / 2, 48, ['FunGen-xQTL Protocol Workflow: implemented 2026 repository view'], size=30, weight='900'))
+svg.append(text_block(W / 2, 80, ['Solid arrows show implemented data flow; dashed panels group analysis families.'], size=16, weight='500', fill=COLORS['muted']))
+
+svg.append(panel(50, 115, 340, 425, 'Inputs & reference data'))
+svg.append(panel(430, 115, 340, 425, 'QC, harmonization & covariates'))
+svg.append(panel(810, 115, 360, 425, 'QTL association & fine-mapping'))
+svg.append(panel(1210, 115, 380, 425, 'GWAS / trait integration'))
+svg.append(panel(430, 600, 1160, 360, 'Validation, prioritization & scores'))
+
+svg.append(box(90, 165, 260, 72, 'GWAS meta-analysis summary statistics', fill='input'))
+svg.append(box(90, 258, 260, 72, 'xQTL summary statistics', fill='input'))
+svg.append(box(90, 351, 260, 72, 'Reference genotype and LD panels', fill='input'))
+svg.append(box(90, 444, 260, 72, 'Context-specific omics', 'expression, splicing, methylation, APA, chromatin, protein / metabolites', fill='input', max_chars=26))
+
+svg.append(box(470, 158, 260, 70, 'Genotype QC, PCA and kinship', fill='process'))
+svg.append(box(470, 252, 260, 80, 'Allele/build harmonization and Z-score correction', fill='process'))
+svg.append(box(470, 356, 260, 80, 'Phenotype QC, normalization and imputation', fill='process'))
+svg.append(box(470, 460, 260, 58, 'Known + hidden covariates', fill='process'))
+
+svg.append(box(850, 150, 280, 72, 'xQTL association testing', 'TensorQTL; quantile QTL', fill='validate'))
+svg.append(box(850, 246, 280, 82, 'Univariate fine-mapping and TWAS weights', 'SuSiE, RSS, fSuSiE', fill='validate'))
+svg.append(box(850, 352, 280, 82, 'Multivariate / multi-gene fine-mapping', 'mvSuSiE, mr.mash, TAD windows', fill='validate'))
+svg.append(box(850, 458, 280, 58, 'Omics prediction databases', fill='output'))
+
+svg.append(box(1250, 150, 300, 72, 'SuSiE-enloc enrichment', 'global xQTL-GWAS priors', fill='integrate'))
+svg.append(box(1250, 246, 300, 72, 'Pairwise colocalization', 'shared causal variants', fill='integrate'))
+svg.append(box(1250, 342, 300, 82, 'TWAS → cTWAS → MR', 'gene-trait association and causal follow-up', fill='integrate'))
+svg.append(box(1250, 458, 300, 58, 'ColocBoost and coloc post-processing', fill='integrate'))
+
+svg.append(box(475, 665, 235, 72, 'EOO annotation enrichment', 'LOCO jackknife', fill='process'))
+svg.append(box(745, 665, 235, 72, 'Pathway / gene set enrichment', 'GSEA multi-database', fill='process'))
+svg.append(box(1015, 665, 235, 72, 'GREGOR and sLDSC', 'variant and heritability enrichment', fill='process'))
+svg.append(box(1285, 665, 235, 72, 'xQTL modifier score', 'EMS training and prediction', fill='process'))
+svg.append(box(600, 810, 260, 76, 'Variant, locus, gene and region prioritization', fill='output'))
+svg.append(box(1015, 810, 260, 76, "Alzheimer's disease biology and follow-up hypotheses", fill='output'))
+
+for y in [201, 294, 390, 480]:
+    svg.append(arrow(350, y, 470, y))
+for y1, y2 in [(193, 186), (292, 286), (396, 393), (489, 487)]:
+    svg.append(arrow(730, y1, 850, y2))
+for y1, y2 in [(186, 186), (287, 282), (392, 383), (487, 487)]:
+    svg.append(arrow(1130, y1, 1250, y2))
+for y1, y2 in [(222, 246), (328, 352), (434, 458)]:
+    svg.append(arrow(980, y1, 980, y2))
+for y1, y2 in [(222, 246), (318, 342), (424, 458)]:
+    svg.append(arrow(1400, y1, 1400, y2))
+for x in [1325, 1400, 1475, 980, 900, 1060]:
+    svg.append(arrow(x, 540, x, 640, dash=True))
+svg.append(arrow(592, 737, 706, 810))
+svg.append(arrow(862, 737, 770, 810))
+svg.append(arrow(1132, 737, 1145, 810))
+svg.append(arrow(1402, 737, 1145, 810))
+svg.append(arrow(860, 848, 1015, 848))
+
+legend_y = 1000
+items = [
+    ('input', 'Inputs'),
+    ('process', 'Implemented processing / validation'),
+    ('validate', 'Association and fine-mapping'),
+    ('integrate', 'Implemented GWAS integration'),
+    ('output', 'Outputs'),
+]
+x = 80
+for key, label in items:
+    svg.append(f'<rect x="{x}" y="{legend_y - 18}" width="28" height="18" rx="4" fill="{COLORS[key]}" stroke="{COLORS["stroke"]}"/>')
+    svg.append(f'<text x="{x + 38}" y="{legend_y - 4}" font-size="15" font-weight="600" fill="#374151">{html.escape(label)}</text>')
+    x += 300 if key != 'input' else 180
+
+svg.append('</svg>')
+OUT.write_text('\n'.join(svg))
+print(OUT)

--- a/code/images/xQTL_Protocol_Implemented_2026.svg
+++ b/code/images/xQTL_Protocol_Implemented_2026.svg
@@ -2,7 +2,7 @@
 <defs><marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L10,3 z" fill="#344054"/></marker></defs>
 <rect width="100%" height="100%" fill="#fbfbf7"/>
 <text x="820.0" y="48.0" text-anchor="middle" font-size="30" font-weight="900" fill="#111827">FunGen-xQTL Protocol Workflow: implemented 2026 repository view</text>
-<text x="820.0" y="80.0" text-anchor="middle" font-size="16" font-weight="500" fill="#667085">Solid arrows show implemented data flow; dashed panels group analysis families.</text>
+<text x="820.0" y="80.0" text-anchor="middle" font-size="16" font-weight="500" fill="#667085">Condensed implementation view audited against Protocol _2024_Mar.json; not a replacement for the detailed schematic.</text>
 <rect x="50" y="115" width="340" height="425" rx="18" fill="#ffffff" stroke="#94a3b8" stroke-width="2.5" stroke-dasharray="14 10"/>
 <text x="220.0" y="149.0" text-anchor="middle" font-size="22" font-weight="800" fill="#1f2937">Inputs &amp; reference data</text>
 <rect x="430" y="115" width="340" height="425" rx="18" fill="#ffffff" stroke="#94a3b8" stroke-width="2.5" stroke-dasharray="14 10"/>
@@ -128,4 +128,5 @@
 <text x="898" y="996" font-size="15" font-weight="600" fill="#374151">Implemented GWAS integration</text>
 <rect x="1160" y="982" width="28" height="18" rx="4" fill="#e0e7ff" stroke="#344054"/>
 <text x="1198" y="996" font-size="15" font-weight="600" fill="#374151">Outputs</text>
+<text x="820.0" y="1045.0" text-anchor="middle" font-size="14" font-weight="500" fill="#667085">Source audit: Protocol _2024_Mar.json; grouped for readability and implementation status.</text>
 </svg>

--- a/code/images/xQTL_Protocol_Implemented_2026.svg
+++ b/code/images/xQTL_Protocol_Implemented_2026.svg
@@ -1,0 +1,131 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1640" height="1080" viewBox="0 0 1640 1080">
+<defs><marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="3" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,6 L10,3 z" fill="#344054"/></marker></defs>
+<rect width="100%" height="100%" fill="#fbfbf7"/>
+<text x="820.0" y="48.0" text-anchor="middle" font-size="30" font-weight="900" fill="#111827">FunGen-xQTL Protocol Workflow: implemented 2026 repository view</text>
+<text x="820.0" y="80.0" text-anchor="middle" font-size="16" font-weight="500" fill="#667085">Solid arrows show implemented data flow; dashed panels group analysis families.</text>
+<rect x="50" y="115" width="340" height="425" rx="18" fill="#ffffff" stroke="#94a3b8" stroke-width="2.5" stroke-dasharray="14 10"/>
+<text x="220.0" y="149.0" text-anchor="middle" font-size="22" font-weight="800" fill="#1f2937">Inputs &amp; reference data</text>
+<rect x="430" y="115" width="340" height="425" rx="18" fill="#ffffff" stroke="#94a3b8" stroke-width="2.5" stroke-dasharray="14 10"/>
+<text x="600.0" y="149.0" text-anchor="middle" font-size="22" font-weight="800" fill="#1f2937">QC, harmonization &amp; covariates</text>
+<rect x="810" y="115" width="360" height="425" rx="18" fill="#ffffff" stroke="#94a3b8" stroke-width="2.5" stroke-dasharray="14 10"/>
+<text x="990.0" y="149.0" text-anchor="middle" font-size="22" font-weight="800" fill="#1f2937">QTL association &amp; fine-mapping</text>
+<rect x="1210" y="115" width="380" height="425" rx="18" fill="#ffffff" stroke="#94a3b8" stroke-width="2.5" stroke-dasharray="14 10"/>
+<text x="1400.0" y="149.0" text-anchor="middle" font-size="22" font-weight="800" fill="#1f2937">GWAS / trait integration</text>
+<rect x="430" y="600" width="1160" height="360" rx="18" fill="#ffffff" stroke="#94a3b8" stroke-width="2.5" stroke-dasharray="14 10"/>
+<text x="1010.0" y="634.0" text-anchor="middle" font-size="22" font-weight="800" fill="#1f2937">Validation, prioritization &amp; scores</text>
+<rect x="90" y="165" width="260" height="72" rx="14" fill="#dbeafe" stroke="#344054" stroke-width="2"/>
+<text x="220.0" y="196.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">GWAS meta-analysis</text>
+<text x="220.0" y="219.2" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">summary statistics</text>
+<rect x="90" y="258" width="260" height="72" rx="14" fill="#dbeafe" stroke="#344054" stroke-width="2"/>
+<text x="220.0" y="300.3" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">xQTL summary statistics</text>
+<rect x="90" y="351" width="260" height="72" rx="14" fill="#dbeafe" stroke="#344054" stroke-width="2"/>
+<text x="220.0" y="382.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Reference genotype and</text>
+<text x="220.0" y="405.2" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">LD panels</text>
+<rect x="90" y="444" width="260" height="72" rx="14" fill="#dbeafe" stroke="#344054" stroke-width="2"/>
+<text x="220.0" y="453.6" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Context-specific omics</text>
+<text x="220.0" y="482.0" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">expression, splicing, methylation,</text>
+<text x="220.0" y="500.0" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">APA, chromatin, protein /</text>
+<text x="220.0" y="518.0" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">metabolites</text>
+<rect x="470" y="158" width="260" height="70" rx="14" fill="#dcfce7" stroke="#344054" stroke-width="2"/>
+<text x="600.0" y="188.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Genotype QC, PCA and</text>
+<text x="600.0" y="211.2" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">kinship</text>
+<rect x="470" y="252" width="260" height="80" rx="14" fill="#dcfce7" stroke="#344054" stroke-width="2"/>
+<text x="600.0" y="276.5" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Allele/build</text>
+<text x="600.0" y="299.3" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">harmonization and</text>
+<text x="600.0" y="322.1" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Z-score correction</text>
+<rect x="470" y="356" width="260" height="80" rx="14" fill="#dcfce7" stroke="#344054" stroke-width="2"/>
+<text x="600.0" y="380.5" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Phenotype QC,</text>
+<text x="600.0" y="403.3" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">normalization and</text>
+<text x="600.0" y="426.1" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">imputation</text>
+<rect x="470" y="460" width="260" height="58" rx="14" fill="#dcfce7" stroke="#344054" stroke-width="2"/>
+<text x="600.0" y="484.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Known + hidden</text>
+<text x="600.0" y="507.2" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">covariates</text>
+<rect x="850" y="150" width="280" height="72" rx="14" fill="#fef3c7" stroke="#344054" stroke-width="2"/>
+<text x="990.0" y="181.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">xQTL association testing</text>
+<text x="990.0" y="209.8" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">TensorQTL; quantile QTL</text>
+<rect x="850" y="246" width="280" height="82" rx="14" fill="#fef3c7" stroke="#344054" stroke-width="2"/>
+<text x="990.0" y="271.5" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Univariate fine-mapping</text>
+<text x="990.0" y="294.3" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">and TWAS weights</text>
+<text x="990.0" y="322.3" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">SuSiE, RSS, fSuSiE</text>
+<rect x="850" y="352" width="280" height="82" rx="14" fill="#fef3c7" stroke="#344054" stroke-width="2"/>
+<text x="990.0" y="377.5" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Multivariate /</text>
+<text x="990.0" y="400.3" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">multi-gene fine-mapping</text>
+<text x="990.0" y="428.3" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">mvSuSiE, mr.mash, TAD windows</text>
+<rect x="850" y="458" width="280" height="58" rx="14" fill="#e0e7ff" stroke="#344054" stroke-width="2"/>
+<text x="990.0" y="482.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Omics prediction</text>
+<text x="990.0" y="505.2" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">databases</text>
+<rect x="1250" y="150" width="300" height="72" rx="14" fill="#fee2e2" stroke="#344054" stroke-width="2"/>
+<text x="1400.0" y="181.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">SuSiE-enloc enrichment</text>
+<text x="1400.0" y="209.8" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">global xQTL-GWAS priors</text>
+<rect x="1250" y="246" width="300" height="72" rx="14" fill="#fee2e2" stroke="#344054" stroke-width="2"/>
+<text x="1400.0" y="277.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Pairwise colocalization</text>
+<text x="1400.0" y="305.8" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">shared causal variants</text>
+<rect x="1250" y="342" width="300" height="82" rx="14" fill="#fee2e2" stroke="#344054" stroke-width="2"/>
+<text x="1400.0" y="367.5" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">TWAS → cTWAS → MR</text>
+<text x="1400.0" y="395.9" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">gene-trait association and</text>
+<text x="1400.0" y="413.9" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">causal follow-up</text>
+<rect x="1250" y="458" width="300" height="58" rx="14" fill="#fee2e2" stroke="#344054" stroke-width="2"/>
+<text x="1400.0" y="482.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">ColocBoost and coloc</text>
+<text x="1400.0" y="505.2" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">post-processing</text>
+<rect x="475" y="665" width="235" height="72" rx="14" fill="#dcfce7" stroke="#344054" stroke-width="2"/>
+<text x="592.5" y="685.5" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">EOO annotation</text>
+<text x="592.5" y="708.3" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">enrichment</text>
+<text x="592.5" y="736.3" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">LOCO jackknife</text>
+<rect x="745" y="665" width="235" height="72" rx="14" fill="#dcfce7" stroke="#344054" stroke-width="2"/>
+<text x="862.5" y="685.5" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Pathway / gene set</text>
+<text x="862.5" y="708.3" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">enrichment</text>
+<text x="862.5" y="736.3" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">GSEA multi-database</text>
+<rect x="1015" y="665" width="235" height="72" rx="14" fill="#dcfce7" stroke="#344054" stroke-width="2"/>
+<text x="1132.5" y="685.5" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">GREGOR and sLDSC</text>
+<text x="1132.5" y="713.9" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">variant and heritability</text>
+<text x="1132.5" y="731.9" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">enrichment</text>
+<rect x="1285" y="665" width="235" height="72" rx="14" fill="#dcfce7" stroke="#344054" stroke-width="2"/>
+<text x="1402.5" y="696.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">xQTL modifier score</text>
+<text x="1402.5" y="724.8" text-anchor="middle" font-size="15" font-weight="500" fill="#667085">EMS training and prediction</text>
+<rect x="600" y="810" width="260" height="76" rx="14" fill="#e0e7ff" stroke="#344054" stroke-width="2"/>
+<text x="730.0" y="843.4" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Variant, locus, gene and</text>
+<text x="730.0" y="866.2" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">region prioritization</text>
+<rect x="1015" y="810" width="260" height="76" rx="14" fill="#e0e7ff" stroke="#344054" stroke-width="2"/>
+<text x="1145.0" y="832.5" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">Alzheimer&#x27;s disease</text>
+<text x="1145.0" y="855.3" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">biology and follow-up</text>
+<text x="1145.0" y="878.1" text-anchor="middle" font-size="19" font-weight="700" fill="#111827">hypotheses</text>
+<line x1="350" y1="201" x2="470" y2="201" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="350" y1="294" x2="470" y2="294" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="350" y1="390" x2="470" y2="390" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="350" y1="480" x2="470" y2="480" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="730" y1="193" x2="850" y2="186" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="730" y1="292" x2="850" y2="286" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="730" y1="396" x2="850" y2="393" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="730" y1="489" x2="850" y2="487" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="1130" y1="186" x2="1250" y2="186" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="1130" y1="287" x2="1250" y2="282" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="1130" y1="392" x2="1250" y2="383" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="1130" y1="487" x2="1250" y2="487" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="980" y1="222" x2="980" y2="246" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="980" y1="328" x2="980" y2="352" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="980" y1="434" x2="980" y2="458" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="1400" y1="222" x2="1400" y2="246" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="1400" y1="318" x2="1400" y2="342" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="1400" y1="424" x2="1400" y2="458" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="1325" y1="540" x2="1325" y2="640" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" stroke-dasharray="8 8"/>
+<line x1="1400" y1="540" x2="1400" y2="640" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" stroke-dasharray="8 8"/>
+<line x1="1475" y1="540" x2="1475" y2="640" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" stroke-dasharray="8 8"/>
+<line x1="980" y1="540" x2="980" y2="640" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" stroke-dasharray="8 8"/>
+<line x1="900" y1="540" x2="900" y2="640" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" stroke-dasharray="8 8"/>
+<line x1="1060" y1="540" x2="1060" y2="640" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" stroke-dasharray="8 8"/>
+<line x1="592" y1="737" x2="706" y2="810" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="862" y1="737" x2="770" y2="810" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="1132" y1="737" x2="1145" y2="810" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="1402" y1="737" x2="1145" y2="810" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<line x1="860" y1="848" x2="1015" y2="848" stroke="#344054" stroke-width="3" marker-end="url(#arrow)" />
+<rect x="80" y="982" width="28" height="18" rx="4" fill="#dbeafe" stroke="#344054"/>
+<text x="118" y="996" font-size="15" font-weight="600" fill="#374151">Inputs</text>
+<rect x="260" y="982" width="28" height="18" rx="4" fill="#dcfce7" stroke="#344054"/>
+<text x="298" y="996" font-size="15" font-weight="600" fill="#374151">Implemented processing / validation</text>
+<rect x="560" y="982" width="28" height="18" rx="4" fill="#fef3c7" stroke="#344054"/>
+<text x="598" y="996" font-size="15" font-weight="600" fill="#374151">Association and fine-mapping</text>
+<rect x="860" y="982" width="28" height="18" rx="4" fill="#fee2e2" stroke="#344054"/>
+<text x="898" y="996" font-size="15" font-weight="600" fill="#374151">Implemented GWAS integration</text>
+<rect x="1160" y="982" width="28" height="18" rx="4" fill="#e0e7ff" stroke="#344054"/>
+<text x="1198" y="996" font-size="15" font-weight="600" fill="#374151">Outputs</text>
+</svg>

--- a/code/images/xQTL_Protocol_Implemented_2026_notes.md
+++ b/code/images/xQTL_Protocol_Implemented_2026_notes.md
@@ -1,0 +1,23 @@
+# Updated FunGen-xQTL workflow plot notes
+
+## Relationship to the existing Lucidchart figure
+
+The generated `xQTL_Protocol_Implemented_2026.svg` is not intended to replace the detailed Lucidchart schematic exported as `Protocol _2024_Mar.json`. The Lucidchart export is the richer source diagram: it contains multiple pages and dozens of labels covering fine-grained protocol concepts, including data sources, omics contexts, QC, association testing, fine-mapping, integration, prioritization, and Alzheimer’s disease follow-up.
+
+The generated SVG is a condensed implementation view. It groups related Lucidchart nodes into fewer boxes so readers can quickly see which broad workflow families are represented in the current repository and how downstream integrative analyses follow association testing and fine-mapping.
+
+## What changed relative to the existing plot
+
+- The detailed Lucidchart boxes for existing GWAS/xQTL summary statistics, reference genotype data, LD reference panels, and context-specific xQTL assays are grouped into an `Inputs & reference data` panel.
+- Genotype QC, PCA, kinship, allele/build harmonization, phenotype QC, imputation, and covariate inference are grouped into a `QC, harmonization & covariates` panel.
+- xQTL association, quantile QTL, univariate fine-mapping/TWAS weights, multivariate or multi-gene fine-mapping, and omics prediction databases are grouped into a `QTL association & fine-mapping` panel.
+- The downstream integrative-analysis portion is made more explicit with a `GWAS / trait integration` panel covering SuSiE-enloc enrichment, pairwise colocalization, TWAS to cTWAS to MR, and ColocBoost / coloc post-processing.
+- Validation and prioritization are separated into a bottom panel covering annotation/pathway/heredity enrichment, EMS, prioritization outputs, and Alzheimer’s disease follow-up hypotheses.
+
+## Why this can be useful
+
+The existing Lucidchart figure is better for a full conceptual overview. The generated SVG is better only for a narrower purpose: it is smaller, reproducible from source control, easier to edit programmatically, and emphasizes implemented downstream analysis families after QTL association and fine-mapping.
+
+## Limitations
+
+This generated SVG deliberately omits many fine-grained Lucidchart labels and citations to keep the figure readable. It should therefore be treated as a documentation companion or implementation overlay, not as the authoritative protocol schematic.


### PR DESCRIPTION
### Motivation
- Add a reproducible programmatic way to produce an up-to-date visual summary of the FunGen-xQTL protocol implemented in 2026, including inputs, processing, association/fine-mapping, integration and outputs. 
- Provide a human-readable repository artifact (SVG) that documents implemented data flow and groupings for use in docs and presentations.

### Description
- Add a new script `code/images/generate_updated_workflow.py` that programmatically constructs an SVG using helper functions `wrap`, `text_block`, `box`, `arrow`, and `panel`, and writes the output to `xQTL_Protocol_Implemented_2026.svg`.
- Include a generated SVG `code/images/xQTL_Protocol_Implemented_2026.svg` representing the workflow with panels, colored boxes, arrows, and a legend; the script also prints the output path when run.
- Centralize styling and layout via the `COLORS`, width/height constants, and reusable drawing primitives to make updates and regeneration straightforward.

### Testing
- No automated tests were run for these additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa69db1de08332b0ef09ef1fc95caf)