### PR TITLE
Add SVG generator to extend protocol figure and include generated SVG and notes

### DIFF
--- a/code/images/generate_updated_workflow.py
+++ b/code/images/generate_updated_workflow.py
@@ -1,0 +1,164 @@
+"""Generate a Lucidchart-based workflow SVG with repository additions.
+
+The generated figure keeps the existing protocol figure intact by embedding the
+current Lucidchart-derived PNG (`xQTL_Protocol_Feb_2024.png`) as the base layer.
+It then adds a right-side panel for repository components that are not explicit
+in the existing Lucidchart export (`Protocol _2024_Mar.json`).
+"""
+
+from pathlib import Path
+import html
+import json
+import re
+import struct
+
+HERE = Path(__file__).resolve().parent
+LUCIDCHART_JSON = HERE / 'Protocol _2024_Mar.json'
+BASE_FIGURE = HERE / 'xQTL_Protocol_Feb_2024.png'
+OUT = HERE / 'xQTL_Protocol_Implemented_2026.svg'
+
+ADD_ON_COMPONENTS = [
+    ('SuSiE-enloc enrichment', 'xQTL-GWAS enrichment priors before pairwise colocalization'),
+    ('cTWAS workflow', 'TWAS follow-up with variant selection for candidate genes'),
+    ('ColocBoost', 'Additional GWAS/xQTL colocalization method notebook'),
+    ('EOO annotation enrichment', 'Excess-of-overlap validation with chromosome jackknife'),
+    ('Pathway / GSEA enrichment', 'Gene-set interpretation of prioritized genes'),
+    ('GREGOR and sLDSC', 'Variant and partitioned-heritability enrichment workflows'),
+    ('xQTL modifier score', 'EMS training and prediction for variant-prioritization support'),
+]
+
+EXPECTED_BASE_LABELS = [
+    'Existing GWAS & xQTL Summary Statistics',
+    'Context Specfic xQTL',
+    'Genome-wide xQTL Association',
+    'Genome-wide xQTL Fine-mapping',
+    'Colocalization[4]',
+    'TWAS[8]',
+    'Causal TWAS[8]',
+    'Mendelian Randomization[4,9]',
+    'Multi-Context xQTL',
+    "Alzheimer's Disease",
+]
+
+COLORS = {
+    'panel': '#fff7ed',
+    'panel_stroke': '#ea580c',
+    'box': '#ffedd5',
+    'box_alt': '#e0f2fe',
+    'stroke': '#344054',
+    'line': '#c2410c',
+    'title': '#111827',
+    'muted': '#475467',
+}
+
+
+def png_dimensions(path):
+    header = path.read_bytes()[:24]
+    if header[:8] != b'\x89PNG\r\n\x1a\n':
+        raise ValueError(f'Expected a PNG file: {path}')
+    return struct.unpack('>II', header[16:24])
+
+
+def lucidchart_labels():
+    data = json.loads(LUCIDCHART_JSON.read_text())
+    labels = set()
+    for page in data.get('pages', []):
+        for shape in page.get('items', {}).get('shapes', []):
+            text = ' '.join(area.get('text', '') for area in shape.get('textAreas', []))
+            text = re.sub(r'\s+', ' ', text).strip()
+            if text:
+                labels.add(text)
+    return labels
+
+
+def assert_base_figure_is_lucidchart_export():
+    labels = lucidchart_labels()
+    missing = [label for label in EXPECTED_BASE_LABELS if label not in labels]
+    if missing:
+        raise ValueError('Expected Lucidchart labels are missing: ' + ', '.join(missing))
+    print(f'Audited {len(labels)} labels from {LUCIDCHART_JSON.name}')
+
+
+def wrap(text, max_chars):
+    words = text.split()
+    lines, current = [], ''
+    for word in words:
+        candidate = f'{current} {word}'.strip()
+        if len(candidate) <= max_chars:
+            current = candidate
+        else:
+            if current:
+                lines.append(current)
+            current = word
+    if current:
+        lines.append(current)
+    return lines
+
+
+def text_block(x, y, lines, size, weight='600', fill=None, anchor='middle', line_height=1.2):
+    fill = fill or COLORS['title']
+    return '\n'.join(
+        f'<text x="{x}" y="{y + idx * size * line_height:.1f}" text-anchor="{anchor}" '
+        f'font-family="Arial, Helvetica, sans-serif" font-size="{size}" font-weight="{weight}" '
+        f'fill="{fill}">{html.escape(line)}</text>'
+        for idx, line in enumerate(lines)
+    )
+
+
+def box(x, y, w, h, title, subtitle, index):
+    fill = COLORS['box_alt'] if index % 2 else COLORS['box']
+    title_lines = wrap(title, 24)
+    subtitle_lines = wrap(subtitle, 38)
+    start_y = y + 74
+    parts = [f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="28" fill="{fill}" stroke="{COLORS["stroke"]}" stroke-width="6"/>']
+    parts.append(text_block(x + w / 2, start_y, title_lines, size=64, weight='800'))
+    parts.append(text_block(x + w / 2, start_y + 86 * len(title_lines), subtitle_lines, size=44, weight='500', fill=COLORS['muted']))
+    return '\n'.join(parts)
+
+
+def arrow(x1, y1, x2, y2):
+    return f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{COLORS["line"]}" stroke-width="10" marker-end="url(#arrow)" stroke-dasharray="28 18"/>'
+
+
+def generate_svg():
+    assert_base_figure_is_lucidchart_export()
+    base_w, base_h = png_dimensions(BASE_FIGURE)
+    add_w = 1680
+    gap = 90
+    svg_w = base_w + gap + add_w + 90
+    svg_h = base_h
+    panel_x = base_w + gap
+    panel_y = 520
+    panel_w = add_w
+    panel_h = base_h - 1040
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{svg_w}" height="{svg_h}" viewBox="0 0 {svg_w} {svg_h}">',
+        '<defs><marker id="arrow" markerWidth="18" markerHeight="18" refX="15" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,10 L16,5 z" fill="#c2410c"/></marker></defs>',
+        '<rect width="100%" height="100%" fill="#ffffff"/>',
+        f'<image x="0" y="0" width="{base_w}" height="{base_h}" href="{BASE_FIGURE.name}"/>',
+        f'<rect x="{panel_x}" y="{panel_y}" width="{panel_w}" height="{panel_h}" rx="44" fill="{COLORS["panel"]}" stroke="{COLORS["panel_stroke"]}" stroke-width="10" stroke-dasharray="42 28"/>',
+        text_block(panel_x + panel_w / 2, panel_y + 130, ['Repository components to add', 'to the Lucidchart figure'], size=78, weight='900'),
+        text_block(panel_x + panel_w / 2, panel_y + 330, ['Base layer is the existing xQTL_Protocol_Feb_2024.png;', 'boxes below are missing or newly explicit modules.'], size=44, weight='500', fill=COLORS['muted']),
+    ]
+
+    box_x = panel_x + 115
+    box_w = panel_w - 230
+    box_h = 330
+    start_y = panel_y + 560
+    step = 420
+    for idx, (title, subtitle) in enumerate(ADD_ON_COMPONENTS):
+        y = start_y + idx * step
+        svg.append(box(box_x, y, box_w, box_h, title, subtitle, idx))
+        if idx:
+            svg.append(arrow(panel_x + panel_w / 2, y - 92, panel_x + panel_w / 2, y - 8))
+
+    # Dashed callouts from existing integration / validation region into the add-on panel.
+    svg.append(arrow(base_w - 260, 2500, panel_x, start_y + 120))
+    svg.append(arrow(base_w - 260, 3720, panel_x, start_y + 4 * step + 120))
+    svg.append(text_block(panel_x + panel_w / 2, svg_h - 130, [f'Source audit: {LUCIDCHART_JSON.name}; original figure preserved and extended.'], size=42, weight='500', fill=COLORS['muted']))
+    svg.append('</svg>')
+    OUT.write_text('\n'.join(svg))
+    print(OUT)
+
+
+generate_svg()

--- a/code/images/xQTL_Protocol_Implemented_2026.svg
+++ b/code/images/xQTL_Protocol_Implemented_2026.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="8299" height="4939" viewBox="0 0 8299 4939">
+<defs><marker id="arrow" markerWidth="18" markerHeight="18" refX="15" refY="5" orient="auto" markerUnits="strokeWidth"><path d="M0,0 L0,10 L16,5 z" fill="#c2410c"/></marker></defs>
+<rect width="100%" height="100%" fill="#ffffff"/>
+<image x="0" y="0" width="6439" height="4939" href="xQTL_Protocol_Feb_2024.png"/>
+<rect x="6529" y="520" width="1680" height="3899" rx="44" fill="#fff7ed" stroke="#ea580c" stroke-width="10" stroke-dasharray="42 28"/>
+<text x="7369.0" y="650.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="78" font-weight="900" fill="#111827">Repository components to add</text>
+<text x="7369.0" y="743.6" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="78" font-weight="900" fill="#111827">to the Lucidchart figure</text>
+<text x="7369.0" y="850.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">Base layer is the existing xQTL_Protocol_Feb_2024.png;</text>
+<text x="7369.0" y="902.8" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">boxes below are missing or newly explicit modules.</text>
+<rect x="6644" y="1080" width="1450" height="330" rx="28" fill="#ffedd5" stroke="#344054" stroke-width="6"/>
+<text x="7369.0" y="1154.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="800" fill="#111827">SuSiE-enloc enrichment</text>
+<text x="7369.0" y="1240.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">xQTL-GWAS enrichment priors before</text>
+<text x="7369.0" y="1292.8" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">pairwise colocalization</text>
+<rect x="6644" y="1500" width="1450" height="330" rx="28" fill="#e0f2fe" stroke="#344054" stroke-width="6"/>
+<text x="7369.0" y="1574.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="800" fill="#111827">cTWAS workflow</text>
+<text x="7369.0" y="1660.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">TWAS follow-up with variant selection</text>
+<text x="7369.0" y="1712.8" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">for candidate genes</text>
+<line x1="7369.0" y1="1408" x2="7369.0" y2="1492" stroke="#c2410c" stroke-width="10" marker-end="url(#arrow)" stroke-dasharray="28 18"/>
+<rect x="6644" y="1920" width="1450" height="330" rx="28" fill="#ffedd5" stroke="#344054" stroke-width="6"/>
+<text x="7369.0" y="1994.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="800" fill="#111827">ColocBoost</text>
+<text x="7369.0" y="2080.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">Additional GWAS/xQTL colocalization</text>
+<text x="7369.0" y="2132.8" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">method notebook</text>
+<line x1="7369.0" y1="1828" x2="7369.0" y2="1912" stroke="#c2410c" stroke-width="10" marker-end="url(#arrow)" stroke-dasharray="28 18"/>
+<rect x="6644" y="2340" width="1450" height="330" rx="28" fill="#e0f2fe" stroke="#344054" stroke-width="6"/>
+<text x="7369.0" y="2414.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="800" fill="#111827">EOO annotation</text>
+<text x="7369.0" y="2490.8" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="800" fill="#111827">enrichment</text>
+<text x="7369.0" y="2586.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">Excess-of-overlap validation with</text>
+<text x="7369.0" y="2638.8" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">chromosome jackknife</text>
+<line x1="7369.0" y1="2248" x2="7369.0" y2="2332" stroke="#c2410c" stroke-width="10" marker-end="url(#arrow)" stroke-dasharray="28 18"/>
+<rect x="6644" y="2760" width="1450" height="330" rx="28" fill="#ffedd5" stroke="#344054" stroke-width="6"/>
+<text x="7369.0" y="2834.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="800" fill="#111827">Pathway / GSEA</text>
+<text x="7369.0" y="2910.8" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="800" fill="#111827">enrichment</text>
+<text x="7369.0" y="3006.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">Gene-set interpretation of prioritized</text>
+<text x="7369.0" y="3058.8" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">genes</text>
+<line x1="7369.0" y1="2668" x2="7369.0" y2="2752" stroke="#c2410c" stroke-width="10" marker-end="url(#arrow)" stroke-dasharray="28 18"/>
+<rect x="6644" y="3180" width="1450" height="330" rx="28" fill="#e0f2fe" stroke="#344054" stroke-width="6"/>
+<text x="7369.0" y="3254.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="800" fill="#111827">GREGOR and sLDSC</text>
+<text x="7369.0" y="3340.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">Variant and partitioned-heritability</text>
+<text x="7369.0" y="3392.8" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">enrichment workflows</text>
+<line x1="7369.0" y1="3088" x2="7369.0" y2="3172" stroke="#c2410c" stroke-width="10" marker-end="url(#arrow)" stroke-dasharray="28 18"/>
+<rect x="6644" y="3600" width="1450" height="330" rx="28" fill="#ffedd5" stroke="#344054" stroke-width="6"/>
+<text x="7369.0" y="3674.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="64" font-weight="800" fill="#111827">xQTL modifier score</text>
+<text x="7369.0" y="3760.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">EMS training and prediction for</text>
+<text x="7369.0" y="3812.8" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="44" font-weight="500" fill="#475467">variant-prioritization support</text>
+<line x1="7369.0" y1="3508" x2="7369.0" y2="3592" stroke="#c2410c" stroke-width="10" marker-end="url(#arrow)" stroke-dasharray="28 18"/>
+<line x1="6179" y1="2500" x2="6529" y2="1200" stroke="#c2410c" stroke-width="10" marker-end="url(#arrow)" stroke-dasharray="28 18"/>
+<line x1="6179" y1="3720" x2="6529" y2="2880" stroke="#c2410c" stroke-width="10" marker-end="url(#arrow)" stroke-dasharray="28 18"/>
+<text x="7369.0" y="4809.0" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="42" font-weight="500" fill="#475467">Source audit: Protocol _2024_Mar.json; original figure preserved and extended.</text>
+</svg>

--- a/code/images/xQTL_Protocol_Implemented_2026_notes.md
+++ b/code/images/xQTL_Protocol_Implemented_2026_notes.md
@@ -1,0 +1,27 @@
+# Updated FunGen-xQTL workflow plot notes
+
+## Relationship to the existing Lucidchart figure
+
+`xQTL_Protocol_Implemented_2026.svg` is now a wholesale visual extension of the existing protocol figure. The generator embeds the current Lucidchart-derived PNG, `xQTL_Protocol_Feb_2024.png`, as the untouched base layer and appends a right-side panel for components that should be added or made more explicit.
+
+The Lucidchart JSON export, `Protocol _2024_Mar.json`, is still used as a source audit. The script checks for expected labels from the original schematic before writing the extended SVG, so the generated asset remains tied to the existing Lucidchart vocabulary.
+
+## What was added to the existing plot
+
+The appended panel adds repository components that are missing from, or not explicit enough in, the existing visual schematic:
+
+- SuSiE-enloc enrichment for xQTL-GWAS enrichment priors before pairwise colocalization.
+- cTWAS workflow after TWAS and variant selection for candidate genes.
+- ColocBoost as an additional GWAS/xQTL colocalization method.
+- EOO annotation enrichment with chromosome jackknife validation.
+- Pathway / GSEA enrichment for interpreting prioritized genes.
+- GREGOR and sLDSC enrichment workflows.
+- xQTL modifier score / EMS training and prediction.
+
+## Why this version is better for the requested purpose
+
+This version keeps the existing Lucidchart figure visually intact rather than replacing it with a simplified redesign. It is better for the requested purpose because reviewers can still recognize the original protocol schematic while seeing a clearly marked add-on panel with the missing implemented repository components.
+
+## Limitations
+
+Because the Lucidchart JSON export in this repository does not include shape coordinates or style geometry, the generator cannot reconstruct the original vector drawing from JSON alone. It therefore preserves the existing PNG as the base figure and uses the JSON only to audit expected source labels.


### PR DESCRIPTION
### Motivation
- Preserve the existing Lucidchart-derived protocol PNG as the base layer while making implemented repository components explicit in a right-side panel. 
- Ensure the extended figure is auditable against the Lucidchart JSON export so the generated asset remains tied to the original schematic.

### Description
- Add `code/images/generate_updated_workflow.py`, a generator that validates expected labels from `Protocol _2024_Mar.json`, reads dimensions from `xQTL_Protocol_Feb_2024.png`, and produces an extended SVG at `xQTL_Protocol_Implemented_2026.svg` with a right-side add-on panel. 
- Embed the original PNG unchanged and draw styled boxes, arrows, and textual callouts for seven repository components defined in `ADD_ON_COMPONENTS`. 
- Include helper functions for PNG dimension parsing, label extraction from Lucidchart JSON, text wrapping, and SVG element construction with a shared color palette. 
- Add the generated SVG `code/images/xQTL_Protocol_Implemented_2026.svg` and explanatory notes `code/images/xQTL_Protocol_Implemented_2026_notes.md` describing the relationship to the Lucidchart export and the items added.

### Testing
- Ran the generator with `python code/images/generate_updated_workflow.py`, which executed successfully and wrote `code/images/xQTL_Protocol_Implemented_2026.svg`. 
- The generator performs a label audit against `Protocol _2024_Mar.json` and will raise a `ValueError` if expected labels are missing, and no such error occurred during the run. 
- No unit tests were added to the repository as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa69db1de08332b0ef09ef1fc95caf)